### PR TITLE
Converts umnRole to a proper [] array structure in JSON log

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,7 +17,9 @@ const janus = require('@nihiliad/janus').methods({
         'url': ctx.req.url,
         'referer': ctx.req.headers['referer'],
         'userAgent': ctx.req.headers['user-agent'],
-        'umnRole': ctx.req.headers['umnrole'],
+        'umnRole': ctx.req.headers['umnrole'].split(';').filter(function(i) {
+          return i.length > 0;
+        }),
       },
       'response': {
         'location': ctx.response.headers['location'],


### PR DESCRIPTION
umnRole strings are often multi-valued and `;`-delimited. Rather than store them as a delimited string in the JSON, this converts them directly to a proper `[]` Array structure and filters empty string values resulting from either an empty umnRole attribute `""` or the possibility of extra `;` delimiters (which shouldn't happen)

Previous:
```javascript
    "request": {
      "method": "GET",
      "url": "/janus?search=blitzkrieg&target=MncatDiscovery",
      "referer": "https://www.lib.umn.edu/",
      "umnRole": "tc.staff.xxx.yyy.zzzz;tc.fac.aaa.bbb.cccc"
    },
```

New:
```javascript
    "request": {
      "method": "GET",
      "url": "/janus?search=blitzkrieg&target=MncatDiscovery",
      "referer": "https://www.lib.umn.edu/",
      "umnRole": [
          "tc.staff.xxx.yyy.zzzz",
          "tc.fac.aaa.bbb.cccc"
      ]
    },
```

Previous empty:
```javascript
      "umnRole": ""
```

New empty:
```javascript
      "umnRole": []
```
