### PR TITLE
Temporary support for apache mod_rewrite params=target|scope handling

### DIFF
--- a/capistrano/config/deploy.rb
+++ b/capistrano/config/deploy.rb
@@ -1,6 +1,6 @@
 set :application, 'janus'
 set :repo_url, 'git@github.com:UMNLibraries/janus-deploy.git'
-set :branch, 'master'
+set :branch, 'main'
 
 # Default branch is :master
 # ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call

--- a/capistrano/templates/janus.conf.erb
+++ b/capistrano/templates/janus.conf.erb
@@ -29,5 +29,5 @@ RewriteEngine ON
 # Do not apply this if a target= was already received
 RewriteCond %{THE_REQUEST} !target=
 # Support encoded %7C (insensitive) or | delimited params=target|scope
-RewriteCond %{QUERY_STRING} "params=([A-Za-z_]+)(?:\%7[Cc]|\|)([A-Za-z0-9 _]*)"
+RewriteCond %{QUERY_STRING} "params=([A-Za-z_]+)(?:\%7[Cc]|\|)([^&]*)"
 RewriteRule ^/<%= fetch(:application) %> /<%= fetch(:application) %>?target=%1&scope=%2 [L,R=301,QSA]

--- a/capistrano/templates/janus.conf.erb
+++ b/capistrano/templates/janus.conf.erb
@@ -29,5 +29,5 @@ RewriteEngine ON
 # Do not apply this if a target= was already received
 RewriteCond %{THE_REQUEST} !target=
 # Support encoded %7C (insensitive) or | delimited params=target|scope
-RewriteCond %{QUERY_STRING} "params=([A-Za-z_]+)(?:\%7[Cc]|\|)([A-Za-z0-9_]*)"
+RewriteCond %{QUERY_STRING} "params=([A-Za-z_]+)(?:\%7[Cc]|\|)([A-Za-z0-9 _]*)"
 RewriteRule ^/<%= fetch(:application) %> /<%= fetch(:application) %>?target=%1&scope=%2 [L,R=301,QSA]

--- a/capistrano/templates/janus.conf.erb
+++ b/capistrano/templates/janus.conf.erb
@@ -23,3 +23,11 @@ Alias /<%= fetch(:application) %> <%= fetch(:deploy_to) %>/current/public
   # settings, but the rewritten request doesn't."
   # -- https://wiki.shibboleth.net/confluence/display/SHIB2/NativeSPApacheConfig
 </Location>
+
+# Temporary support for ?params=targetvalue|scopevalue
+RewriteEngine ON
+# Do not apply this if a target= was already received
+RewriteCond %{THE_REQUEST} !target=
+# Support encoded %7C (insensitive) or | delimited params=target|scope
+RewriteCond %{QUERY_STRING} "params=([A-Za-z_]+)(?:\%7[Cc]|\|)([A-Za-z0-9_]*)"
+RewriteRule ^/<%= fetch(:application) %> /<%= fetch(:application) %>?target=%1&scope=%2 [L,R=301,QSA]


### PR DESCRIPTION
Apache mod_rewrite support added to handle `?params=targetvalue|scopevalue&search=search+string` type queries, translating them into `?target=targetvalue&scope=scopevalue&search=search+string`

The rewrite supports:
* literal pipe `|` delimited strings like `params=targetvalue|scopevalue`
* entity encoded pipes (what browsers are most likely to send if a form has literal pipes), case insensitively `params=targetvalue%7Cscopevalue`
* Empty scope values `params=targetvalue|`