### PR TITLE
Apache noescape flag for params=target|scpoe rewrite

### DIFF
--- a/capistrano/templates/janus.conf.erb
+++ b/capistrano/templates/janus.conf.erb
@@ -30,4 +30,4 @@ RewriteEngine ON
 RewriteCond %{THE_REQUEST} !target=
 # Support encoded %7C (insensitive) or | delimited params=target|scope
 RewriteCond %{QUERY_STRING} "params=([A-Za-z_]+)(?:\%7[Cc]|\|)([^&]*)"
-RewriteRule ^/<%= fetch(:application) %> /<%= fetch(:application) %>?target=%1&scope=%2 [L,R=301,QSA]
+RewriteRule ^/<%= fetch(:application) %> /<%= fetch(:application) %>?target=%1&scope=%2 [L,R=301,QSA,NE]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "janus-deploy",
-  "version": "3.1.0",
+  "version": "3.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "janus-deploy",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Deploys the Janus web application for UMN Libraries.",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
When using the temporary Apache rewrite `?params=target|scope&search="search terms"`  method, Apache is double-escaping the appended query string from `search=` which is breaking especially quoted searches.

`[NE]` in this context informs Apache not to do further escaping - it has already been done on the input params. It returns to the exact URLs which were produced using basic `?target=targetname&scope=scopename&search="search terms"`